### PR TITLE
Add `--gh` and `--section` flags to "blurb add"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        # Temporarily remove 3.13 pending:
+        # https://github.com/pytest-dev/pyfakefs/issues/1017
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -110,11 +110,13 @@ Here's how you interact with the file:
 
 * Add the GitHub issue number for this commit to the
   end of the `.. gh-issue:` line.
+  Can be passed on the CLI via the `--gh` flag.
 
 * Uncomment the line with the relevant `Misc/NEWS` section for this entry.
   For example, if this should go in the `Library` section, uncomment
   the line reading `#.. section: Library`.  To uncomment, just delete
   the `#` at the front of the line.
+  Can be passed on the CLI via the `--section` flag.
 
 * Finally, go to the end of the file, and enter your `NEWS` entry.
   This should be a single paragraph of English text using
@@ -238,6 +240,12 @@ final version directory, you'd have to move those around as
 part of the cherry-picking process.
 
 ## Changelog
+
+### 1.2.0
+
+- Add the `--gh` and `--section` flags to the `add` command.
+  This lets you pre-fill-in the `gh-issue` and `section` fields
+  in the template.
 
 ### 1.1.0
 


### PR DESCRIPTION
Fixes https://github.com/python/blurb/issues/6.

Updated version of https://github.com/python/core-workflow/pull/312 but with `--gh` instead of `--bpo`.

# Examples

## Success cases

### `blurb add` opens the usual empty template

```
#
# Please enter the relevant GitHub issue number here:
#
.. gh-issue: 

#
# Uncomment one of these "section:" lines to specify which section
# this entry should go in in Misc/NEWS.d.
#
#.. section: Security
#.. section: Core and Builtins
#.. section: Library
#.. section: Documentation
#.. section: Tests
#.. section: Build
#.. section: Windows
#.. section: macOS
#.. section: IDLE
#.. section: Tools/Demos
#.. section: C API


# Write your Misc/NEWS.d entry below.  It should be a simple ReST paragraph.
# Don't start with "- Issue #<n>: " or "- gh-issue-<n>: " or that sort of stuff.
###########################################################################


```

### `blurb add --gh 123456` opens the template with `gh-issue` filled in

```
#
# Please enter the relevant GitHub issue number here:
#
.. gh-issue: 123456

#
# Uncomment one of these "section:" lines to specify which section
# this entry should go in in Misc/NEWS.d.
#
#.. section: Security
#.. section: Core and Builtins
#.. section: Library
#.. section: Documentation
#.. section: Tests
#.. section: Build
#.. section: Windows
#.. section: macOS
#.. section: IDLE
#.. section: Tools/Demos
#.. section: C API


# Write your Misc/NEWS.d entry below.  It should be a simple ReST paragraph.
# Don't start with "- Issue #<n>: " or "- gh-issue-<n>: " or that sort of stuff.
###########################################################################


```

### `blurb add --section Security` adds an uncommented section

```
#
# Please enter the relevant GitHub issue number here:
#
.. gh-issue: 

#
# Uncomment one of these "section:" lines to specify which section
# this entry should go in in Misc/NEWS.d.
#
#.. section: Security
#.. section: Core and Builtins
#.. section: Library
#.. section: Documentation
#.. section: Tests
#.. section: Build
#.. section: Windows
#.. section: macOS
#.. section: IDLE
#.. section: Tools/Demos
#.. section: C API
.. section: Security


# Write your Misc/NEWS.d entry below.  It should be a simple ReST paragraph.
# Don't start with "- Issue #<n>: " or "- gh-issue-<n>: " or that sort of stuff.
###########################################################################


```
### `blurb add --gh 123456 --section Security` adds both

```
#
# Please enter the relevant GitHub issue number here:
#
.. gh-issue: 123456

#
# Uncomment one of these "section:" lines to specify which section
# this entry should go in in Misc/NEWS.d.
#
#.. section: Security
#.. section: Core and Builtins
#.. section: Library
#.. section: Documentation
#.. section: Tests
#.. section: Build
#.. section: Windows
#.. section: macOS
#.. section: IDLE
#.. section: Tools/Demos
#.. section: C API
.. section: Security


# Write your Misc/NEWS.d entry below.  It should be a simple ReST paragraph.
# Don't start with "- Issue #<n>: " or "- gh-issue-<n>: " or that sort of stuff.
###########################################################################


```

## Error cases

```console
❯ blurb add --gh Security
Error: blurb add --gh argument Security is not a valid integer!

❯ blurb add --section 123456
Error: blurb add --section argument '123456' is not a valid section!  Use one of:
Security
Core and Builtins
Library
Documentation
Tests
Build
Windows
macOS
IDLE
Tools/Demos
C API

❯ blurb add --gh Security --section 123456
Error: blurb add --gh argument Security is not a valid integer!
```


