### PR TITLE
Add `-i/--issue` and `-s/--section` flags to `blurb add`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        # Temporarily remove 3.13 pending:
+        # https://github.com/pytest-dev/pyfakefs/issues/1017
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.2.2
+
+- Add the `-i/--issue` and `-s/--section` options to the `add` command.
+  This lets you pre-fill the `gh-issue` and `section` fields in the template.
+
 ## 1.2.1
 
 - Fix `python3 -m blurb`.

--- a/README.md
+++ b/README.md
@@ -109,12 +109,43 @@ The template for the `blurb add` message looks like this:
 Here's how you interact with the file:
 
 * Add the GitHub issue number for this commit to the
-  end of the `.. gh-issue:` line.
+  end of the `.. gh-issue:` line. The issue can also
+  be specified via the ``-i/--issue`` option:
+
+  ```shell
+  blurb add -i 109198
+  # or equivalently
+  blurb add -i https://github.com/python/cpython/issues/109198
+  ```
 
 * Uncomment the line with the relevant `Misc/NEWS` section for this entry.
   For example, if this should go in the `Library` section, uncomment
   the line reading `#.. section: Library`.  To uncomment, just delete
-  the `#` at the front of the line.
+  the `#` at the front of the line.  Alternatively, the section can
+  be specified via the ``-s/--section`` option:
+
+  ```shell
+  blurb add -s "Library"
+  # or equivalently
+  blurb add -s 3
+  ```
+
+  The section can be referred to from its name (case insensitive) or its ID
+  defined according to the following table:
+
+  | ID | Section           |
+  |----|-------------------|
+  |  1 | Security          |
+  |  2 | Core and Builtins |
+  |  3 | Library           |
+  |  4 | Documentation     |
+  |  5 | Tests             |
+  |  6 | Build             |
+  |  7 | Windows           |
+  |  8 | macOS             |
+  |  9 | IDLE              |
+  | 10 | Tools/Demos       |
+  | 11 | C API             |
 
 * Finally, go to the end of the file, and enter your `NEWS` entry.
   This should be a single paragraph of English text using
@@ -238,6 +269,12 @@ final version directory, you'd have to move those around as
 part of the cherry-picking process.
 
 ## Changelog
+
+### 1.2.0
+
+- Add the `-i/--issue` and `-s/--section` options to the `add` command.
+  This lets you pre-fill-in the `gh-issue` and `section` fields
+  in the template.
 
 ### 1.1.0
 

--- a/README.md
+++ b/README.md
@@ -130,9 +130,8 @@ Here's how you interact with the file:
   $ blurb add -s lib
   ```
 
-  The known section names are given in the following table. The match
-  is performed casse insensitively and partial matching is supported
-  as long as the match is unique.
+  The match is performed case insensitively and partial matching is
+  supported as long as the match is unique.
 
 * Finally, go to the end of the file, and enter your `NEWS` entry.
   This should be a single paragraph of English text using

--- a/README.md
+++ b/README.md
@@ -228,7 +228,6 @@ the right thing.  If `NEWS` entries were already written to the
 final version directory, you'd have to move those around as
 part of the cherry-picking process.
 
-
 ## Copyright
 
 **blurb** is Copyright 2015-2018 by Larry Hastings.

--- a/README.md
+++ b/README.md
@@ -113,9 +113,9 @@ Here's how you interact with the file:
   be specified via the ``-i/--issue`` option:
 
   ```shell
-  blurb add -i 109198
+  $ blurb add -i 109198
   # or equivalently
-  blurb add -i https://github.com/python/cpython/issues/109198
+  $ blurb add -i https://github.com/python/cpython/issues/109198
   ```
 
 * Uncomment the line with the relevant `Misc/NEWS` section for this entry.
@@ -125,27 +125,28 @@ Here's how you interact with the file:
   be specified via the ``-s/--section`` option:
 
   ```shell
-  blurb add -s "Library"
+  $ blurb add -s 'Library'
   # or equivalently
-  blurb add -s 3
+  $ blurb add -s lib
   ```
 
-  The section can be referred to from its name (case insensitive) or its ID
-  defined according to the following table:
+  The known section names are given in the following table. The match
+  is performed casse insensitively and partial matching is supported
+  as long as the match is unique:
 
-  | ID | Section           |
-  |----|-------------------|
-  |  1 | Security          |
-  |  2 | Core and Builtins |
-  |  3 | Library           |
-  |  4 | Documentation     |
-  |  5 | Tests             |
-  |  6 | Build             |
-  |  7 | Windows           |
-  |  8 | macOS             |
-  |  9 | IDLE              |
-  | 10 | Tools/Demos       |
-  | 11 | C API             |
+  | Section Name      |
+  |-------------------|
+  | Security          |
+  | Core and Builtins |
+  | Library           |
+  | Documentation     |
+  | Tests             |
+  | Build             |
+  | Windows           |
+  | macOS             |
+  | IDLE              |
+  | Tools/Demos       |
+  | C API             |
 
 * Finally, go to the end of the file, and enter your `NEWS` entry.
   This should be a single paragraph of English text using

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ part of the cherry-picking process.
 - Move code from `python/core-workflow` to own `python/blurb` repo.
 - Deploy to PyPI via Trusted Publishers.
 - Add the `-i/--issue` and `-s/--section` options to the `add` command.
-  This lets you pre-fill-in the `gh-issue` and `section` fields
+  This lets you pre-fill the `gh-issue` and `section` fields.
   in the template.
 
 ### 1.1.0

--- a/README.md
+++ b/README.md
@@ -132,21 +132,7 @@ Here's how you interact with the file:
 
   The known section names are given in the following table. The match
   is performed casse insensitively and partial matching is supported
-  as long as the match is unique:
-
-  | Section Name      |
-  |-------------------|
-  | Security          |
-  | Core and Builtins |
-  | Library           |
-  | Documentation     |
-  | Tests             |
-  | Build             |
-  | Windows           |
-  | macOS             |
-  | IDLE              |
-  | Tools/Demos       |
-  | C API             |
+  as long as the match is unique.
 
 * Finally, go to the end of the file, and enter your `NEWS` entry.
   This should be a single paragraph of English text using

--- a/src/blurb/blurb.py
+++ b/src/blurb/blurb.py
@@ -1048,7 +1048,7 @@ _format_row = (f'| {{:{_sec_name_width - 2:d}}} |').format
 del _sec_name_width
 sections_table = '\n'.join(map(_format_row, sections))
 del _format_row
-sections_table = '\n'.join((_sec_row_rule, sections_table, _sec_rowrule))
+sections_table = '\n'.join((_sec_row_rule, sections_table, _sec_row_rule))
 del _sec_row_rule
 add.__doc__ = add.__doc__.format(sections=sections_table)
 

--- a/src/blurb/blurb.py
+++ b/src/blurb/blurb.py
@@ -970,10 +970,10 @@ Use -i/--issue to specify a GitHub issue number or link, e.g.:
 The blurb's section can be specified via -s/--section
 with its name (case insenstitive), e.g.:
 
-    blurb add -s 'Core and Builtins'
+    blurb add -s 'Library'
 
     # or using a partial matching
-    blurb add -s core
+    blurb add -s lib
 
 The known sections names are defined as follows and
 spaces in names can be substituted for underscores:

--- a/src/blurb/blurb.py
+++ b/src/blurb/blurb.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """Command-line tool to manage CPython Misc/NEWS.d entries."""
-__version__ = "1.1.1"
+__version__ = "1.2.0"
 
 ##
 ## blurb version 1.0

--- a/src/blurb/blurb.py
+++ b/src/blurb/blurb.py
@@ -886,9 +886,9 @@ def _extract_issue_number(issue):
     if issue.isdigit():
         return issue
 
-    match = re.match(r'^(?:https?://)?github\.com/python/cpython/issues/(\d+)$', issue)
+    match = re.match(r'^(?:https://)?github\.com/python/cpython/issues/(\d+)$', issue)
     if match is None:
-        sys.exit(f"Invalid GitHub Issue: {raw_issue}")
+        sys.exit(f"Invalid GitHub issue: {raw_issue}")
     return match.group(1)
 
 
@@ -1382,7 +1382,7 @@ def main():
 
         if consume_after:
             sys.exit(f"Error: blurb: {subcommand} {consume_after} "
-                     f"most be followed by an option argument")
+                     f"must be followed by an option argument")
 
         sys.exit(fn(*filtered_args, **kwargs))
     except TypeError as e:

--- a/src/blurb/blurb.py
+++ b/src/blurb/blurb.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 """Command-line tool to manage CPython Misc/NEWS.d entries."""
-
 ##
 ## Part of the blurb package.
 ## Copyright 2015-2018 by Larry Hastings
@@ -61,6 +60,7 @@ import time
 import unittest
 
 from . import __version__
+
 
 #
 # This template is the canonical list of acceptable section names!

--- a/src/blurb/blurb.py
+++ b/src/blurb/blurb.py
@@ -908,7 +908,8 @@ def _extract_section_name(section):
     if not section:
         sys.exit(f"Empty section name!")
 
-    section_words = section.lower().replace('_', ' ').split(' ')
+    sanitized = re.sub(r'[_-]', ' ', section)
+    section_words = re.split(r'\s+', sanitized)
     section_pattern = '[_ ]'.join(map(re.escape, section_words))
     section_re = re.compile(section_pattern, re.I)
 
@@ -923,7 +924,9 @@ def _extract_section_name(section):
                  f'{sections_table}')
 
     if len(matches) > 1:
-        sys.exit(f"More than one match for: {raw_section}\n\n"
+        multiple_matches = ', '.join(map(repr, sorted(matches)))
+        sys.exit(f"More than one match for: {raw_section}\n"
+                 f"Matches: {multiple_matches}\n\n"
                  f"Choose from the following table:\n\n"
                  f'{sections_table}')
 

--- a/src/blurb/blurb.py
+++ b/src/blurb/blurb.py
@@ -42,7 +42,6 @@
 import atexit
 import base64
 import builtins
-from collections import defaultdict
 import glob
 import hashlib
 import io
@@ -911,10 +910,12 @@ _section_special_patterns = {__: set() for __ in sections}
 _section_names_lower_nosep = {}
 
 for _section in sections:
-    _sanitized = re.sub(r'[_ /]', ' ', _section)
+    # ' ' and '/' are the separators used by known sections
+    _sanitized = re.sub(r'[ /]', ' ', _section)
     _section_words = re.split(r'\s+', _sanitized)
     _section_names_lower_nosep[_section] = ''.join(_section_words).lower()
     del _sanitized
+    # '_', '-', ' ' and '/' are the allowed (user) separators
     _section_pattern = r'[_\- /]?'.join(map(re.escape, _section_words))
     # add '$' to avoid matching after the pattern
     _section_pattern = f'{_section_pattern}$'
@@ -942,8 +943,8 @@ def _extract_section_name(section):
     # '_', '-', ' ' and '/' are the allowed (user) separators
     sanitized = re.sub(r'[_\- /]', ' ', section)
     section_words = re.split(r'\s+', sanitized)
-    # '_', ' ' and '/' are the separators used by known sections
-    section_pattern = r'[_ /]'.join(map(re.escape, section_words))
+    # ' ' and '/' are the separators used by known sections
+    section_pattern = r'[ /]'.join(map(re.escape, section_words))
     section_pattern = re.compile(section_pattern, re.I)
     for section_name in sections:
         # try to use the input as the pattern to match against known names

--- a/src/blurb/blurb.py
+++ b/src/blurb/blurb.py
@@ -1043,13 +1043,13 @@ spaces in names can be substituted for underscores:
 
 assert sections, 'sections is empty'
 _sec_name_width = 2 + max(map(len, sections))
-_sec_rowrule = '+'.join(['',  '-' * _sec_name_width, ''])
+_sec_row_rule = '+'.join(['',  '-' * _sec_name_width, ''])
 _format_row = (f'| {{:{_sec_name_width - 2:d}}} |').format
 del _sec_name_width
 sections_table = '\n'.join(map(_format_row, sections))
 del _format_row
-sections_table = '\n'.join((_sec_rowrule, sections_table, _sec_rowrule))
-del _sec_rowrule
+sections_table = '\n'.join((_sec_row_rule, sections_table, _sec_rowrule))
+del _sec_row_rule
 add.__doc__ = add.__doc__.format(sections=sections_table)
 
 

--- a/src/blurb/blurb.py
+++ b/src/blurb/blurb.py
@@ -60,10 +60,7 @@ import textwrap
 import time
 import unittest
 
-try:
-    from . import __version__
-except ImportError:
-    __version__ = 12343
+from . import __version__
 
 
 #

--- a/src/blurb/blurb.py
+++ b/src/blurb/blurb.py
@@ -1371,11 +1371,9 @@ def main():
                 kwargs[consume_after] = a
                 consume_after = None
                 continue
-
             if done_with_options:
                 filtered_args.append(a)
                 continue
-
             if a.startswith('-'):
                 if a == "--":
                     done_with_options = True
@@ -1385,7 +1383,6 @@ def main():
                     for s in a[1:]:
                         handle_option(s, short_options)
                 continue
-
             filtered_args.append(a)
 
         if consume_after:

--- a/src/blurb/blurb.py
+++ b/src/blurb/blurb.py
@@ -925,7 +925,7 @@ for _section in sections:
     del _section_pattern, _section
 
 # the following statements will raise KeyError if the names are invalid
-_section_special_patterns['C API'].add(re.compile(r'^((?<=c)[_\- /])?api?$', re.I))
+_section_special_patterns['C API'].add(re.compile(r'^((?<=c)[_\- /])?api$', re.I))
 _section_special_patterns['Core and Builtins'].add(re.compile('^builtins?$', re.I))
 _section_special_patterns['Tools/Demos'].add(re.compile('^dem(?:o|os)?$', re.I))
 

--- a/src/blurb/blurb.py
+++ b/src/blurb/blurb.py
@@ -62,7 +62,6 @@ import unittest
 
 from . import __version__
 
-
 #
 # This template is the canonical list of acceptable section names!
 # It's parsed internally into the "sections" set.

--- a/src/blurb/blurb.py
+++ b/src/blurb/blurb.py
@@ -940,8 +940,8 @@ def _find_smart_matches(section):
     section_words = re.split(r'\s+', sanitized)
     # ' ' and '/' are the separators used by known sections
     section_pattern = r'[ /]'.join(map(re.escape, section_words))
-
     section_pattern = re.compile(section_pattern, re.I)
+
     for section_name in sections:
         # try to use the input as the pattern to match against known names
         if section_pattern.match(section_name):
@@ -958,13 +958,11 @@ def _find_smart_matches(section):
         # try to use the input as the prefix of a flattened section name
         normalized_prefix = ''.join(section_words).lower()
         for section_name, normalized in _section_names_lower_nosep.items():
-            if (
-                len(normalized_prefix) <= len(normalized) and
-                normalized.startswith(normalized_prefix)
-            ):
+            if normalized.startswith(normalized_prefix):
                 matches.append(section_name)
 
     return matches
+
 
 def _extract_section_name(section):
     if section is None:

--- a/tests/test_blurb.py
+++ b/tests/test_blurb.py
@@ -1,7 +1,14 @@
 import pytest
-from pyfakefs.fake_filesystem import FakeFilesystem
 
 from blurb import blurb
+
+
+def test_section_names():
+    assert tuple(blurb.sections) == (
+        'Security', 'Core and Builtins', 'Library', 'Documentation',
+        'Tests', 'Build', 'Windows', 'macOS', 'IDLE', 'Tools/Demos',
+        'C API',
+    )
 
 
 UNCHANGED_SECTIONS = (

--- a/tests/test_blurb_add.py
+++ b/tests/test_blurb_add.py
@@ -135,15 +135,17 @@ class TestValidSectionNames:
     @pytest.mark.parametrize(
         ('section', 'expect'), [
             ('Lib', 'Library'),
-            ('lib', 'Library'),
-            ('lib ', 'Library'),
+            ('Tools', 'Tools/Demos'),
             ('doc', 'Documentation'),
+            ('Core-and-Builtins', 'Core and Builtins'),
+            ('Core_and_Builtins', 'Core and Builtins'),
+            ('Core_and-Builtins', 'Core and Builtins'),
             ('Core and', 'Core and Builtins'),
-            ('core and', 'Core and Builtins'),
             ('Core_and', 'Core and Builtins'),
             ('core_and', 'Core and Builtins'),
             ('core-and', 'Core and Builtins'),
-            ('Tools', 'Tools/Demos'),
+            ('Core   and   Builtins', 'Core and Builtins'),
+            ('cOre _ and - bUILtins', 'Core and Builtins'),
         ]
     )
     def test_partial_names(self, section, expect):

--- a/tests/test_blurb_add.py
+++ b/tests/test_blurb_add.py
@@ -105,9 +105,50 @@ class TestValidSectionNames:
 
     @pytest.mark.parametrize(
         ('section', 'expect'), [
+            ('Sec', 'Security'),
+            ('sec', 'Security'),
+            ('security', 'Security'),
+            ('Core And', 'Core and Builtins'),
+            ('Core And Built', 'Core and Builtins'),
+            ('Core And Builtins', 'Core and Builtins'),
             ('Lib', 'Library'),
-            ('Tools', 'Tools/Demos'),
             ('doc', 'Documentation'),
+            ('document', 'Documentation'),
+            ('Tes', 'Tests'),
+            ('tes', 'Tests'),
+            ('Test', 'Tests'),
+            ('Tests', 'Tests'),
+            ('Buil', 'Build'),
+            ('buil', 'Build'),
+            ('build', 'Build'),
+            ('Tool', 'Tools/Demos'),
+            ('Tools', 'Tools/Demos'),
+            ('Tools/', 'Tools/Demos'),
+            ('core', 'Core and Builtins'),
+        ]
+    )
+    def test_partial_words(self, section, expect):
+        # test that partial matching from the beginning is supported
+        self.check(section, expect)
+
+    @pytest.mark.parametrize(
+        ('section', 'expect'), [
+            ('builtin', 'Core and Builtins'),
+            ('builtins', 'Core and Builtins'),
+            ('api', 'C API'),
+            ('c-api', 'C API'),
+            ('c/api', 'C API'),
+            ('c api', 'C API'),
+            ('dem', 'Tools/Demos'),
+            ('demo', 'Tools/Demos'),
+            ('demos', 'Tools/Demos'),
+        ]
+    )
+    def test_partial_special_names(self, section, expect):
+        self.check(section, expect)
+
+    @pytest.mark.parametrize(
+        ('section', 'expect'), [
             ('Core-and-Builtins', 'Core and Builtins'),
             ('Core_and_Builtins', 'Core and Builtins'),
             ('Core_and-Builtins', 'Core and Builtins'),
@@ -117,10 +158,32 @@ class TestValidSectionNames:
             ('core-and', 'Core and Builtins'),
             ('Core   and   Builtins', 'Core and Builtins'),
             ('cOre _ and - bUILtins', 'Core and Builtins'),
+            ('Tools/demo', 'Tools/Demos'),
+            ('Tools-demo', 'Tools/Demos'),
+            ('Tools demo', 'Tools/Demos'),
         ]
     )
-    def test_partial_names(self, section, expect):
+    def test_partial_separators(self, section, expect):
         self.check(section, expect)
+
+    @pytest.mark.parametrize(
+        ('prefix', 'expect'), [
+            ('corean', 'Core and Builtins'),
+            ('coreand', 'Core and Builtins'),
+            ('coreandbuilt', 'Core and Builtins'),
+            ('coreand Builtins', 'Core and Builtins'),
+            ('coreand Builtins', 'Core and Builtins'),
+            ('coreAnd Builtins', 'Core and Builtins'),
+            ('CoreAnd Builtins', 'Core and Builtins'),
+            ('Coreand', 'Core and Builtins'),
+            ('Coreand Builtins', 'Core and Builtins'),
+            ('Coreand builtin', 'Core and Builtins'),
+            ('Coreand buil', 'Core and Builtins'),
+        ]
+    )
+    def test_partial_prefix_words(self, prefix, expect):
+        # spaces are not needed if we cannot find a correct match
+        self.check(prefix, expect)
 
     @pytest.mark.parametrize(
         ('section', 'expect'),
@@ -147,7 +210,19 @@ def test_empty_section_name(section):
         blurb._update_blurb_template(issue=None, section='')
 
 
-@pytest.mark.parametrize('section', ['libraryy', 'Not a section'])
+@pytest.mark.parametrize('section', [
+    # invalid
+    'invalid',
+    'Not a section',
+    # non-special names
+    'c?api',
+    'cXapi',
+    'C+API',
+    # super-strings
+    'Library and more',
+    'library3',
+    'librari',
+])
 def test_invalid_section_name(section):
     error_message = re.escape(f'Invalid section name: {section!r}')
     error_message = re.compile(rf'{error_message}\n\n.+', re.MULTILINE)

--- a/tests/test_blurb_add.py
+++ b/tests/test_blurb_add.py
@@ -204,14 +204,17 @@ class TestValidSectionNames:
 def test_empty_section_name(section):
     error_message = re.escape('Empty section name!')
     with pytest.raises(SystemExit, match=error_message):
-        blurb._extract_section_name('')
+        blurb._extract_section_name(section)
 
     with pytest.raises(SystemExit, match=error_message):
-        blurb._update_blurb_template(issue=None, section='')
+        blurb._update_blurb_template(issue=None, section=section)
 
 
 @pytest.mark.parametrize('section', [
     # invalid
+    '_',
+    '-',
+    '/',
     'invalid',
     'Not a section',
     # non-special names

--- a/tests/test_blurb_add.py
+++ b/tests/test_blurb_add.py
@@ -1,0 +1,148 @@
+from itertools import chain, product
+import re
+
+import pytest
+
+from blurb import blurb
+
+
+ALLOWED_ISSUE_URL_PREFIX = [
+    'github.com/python/cpython/issues/',
+    'http://github.com/python/cpython/issues/',
+    'https://github.com/python/cpython/issues/'
+]
+
+ALLOWED_SECTION_IDS = list(map(str, range(1 + len(blurb.sections), 1)))
+
+
+def test_valid_no_issue_number():
+    assert blurb._extract_issue_number(None) is None
+    res = blurb._update_blurb_template(issue=None, section=None)
+    lines = res.splitlines()
+    assert f'.. gh-issue:' not in lines
+    assert f'.. gh-issue: ' in lines
+    for line in lines:
+        assert not line.startswith('.. section: ')
+
+
+@pytest.mark.parametrize(('issue', 'expect'), [
+    (f'{w1}{prefix}12345{w2}', '12345')
+    for (w1, w2) in product(['', ' '], repeat=2)
+    for prefix in ('', 'gh-', *ALLOWED_ISSUE_URL_PREFIX)
+])
+def test_valid_issue_number(issue, expect):
+    actual = blurb._extract_issue_number(issue)
+    assert actual == expect
+
+    res = blurb._update_blurb_template(issue=issue, section=None)
+
+    lines = res.splitlines()
+    assert f'.. gh-issue:' not in lines
+    for line in lines:
+        assert not line.startswith('.. section: ')
+
+    assert f'.. gh-issue: {expect}' in lines
+    assert f'.. gh-issue: ' not in lines
+
+
+@pytest.mark.parametrize('issue', [
+    'abc',
+    'gh-abc',
+    'gh-',
+    'bpo-',
+    *[
+        ''.join(_) for _ in
+        product(ALLOWED_ISSUE_URL_PREFIX, ('abc', '1234?param=1'))
+    ]
+])
+def test_invalid_issue_number(issue):
+    error_message = re.escape(f'Invalid GitHub Issue: {issue}')
+    with pytest.raises(SystemExit, match=error_message):
+        blurb._extract_issue_number(issue)
+
+    with pytest.raises(SystemExit, match=error_message):
+        blurb._update_blurb_template(issue=issue, section=None)
+
+
+@pytest.mark.parametrize('section', ALLOWED_SECTION_IDS)
+def test_valid_section_id(section):
+    actual = blurb._extract_section_name(section)
+    assert actual == section
+
+    res = blurb._update_blurb_template(issue=None, section=section)
+    res = res.splitlines()
+    for index, section_id in enumerate(ALLOWED_SECTION_IDS):
+        if section_id == section:
+            assert f'.. section: {blurb.sections[index]}' in res
+        else:
+            assert f'#.. section: {blurb.sections[index]}' in res
+            assert f'.. section: {blurb.sections[index]}' not in res
+
+
+@pytest.mark.parametrize(('section', 'expect'), chain(
+    zip(blurb.sections, blurb.sections),
+    ((s.lower(), s) for s in blurb.sections),
+    ((s.upper(), s) for s in blurb.sections),
+    ((s.replace('_', ' '), s) for s in blurb.sections),
+    ((s.replace('_', ' ').lower(), s) for s in blurb.sections),
+    ((s.replace('_', ' ').upper(), s) for s in blurb.sections),
+))
+def test_valid_section_name(section, expect):
+    actual = blurb._extract_section_name(section)
+    assert actual == expect
+
+    res = blurb._update_blurb_template(issue=None, section=section)
+    res = res.splitlines()
+    for section_name in blurb.sections:
+        if section_name == expect:
+            assert f'.. section: {section_name}' in res
+        else:
+            assert f'#.. section: {section_name}' in res
+            assert f'.. section: {section_name}' not in res
+
+
+@pytest.mark.parametrize('section', ['-1', '0', '1337'])
+def test_invalid_section_id(section):
+    error_message = re.escape(f'Invalid section ID: {int(section)}')
+    error_message = re.compile(rf'{error_message}\n\n.+', re.MULTILINE)
+    with pytest.raises(SystemExit, match=error_message):
+        blurb._extract_section_name(section)
+
+    with pytest.raises(SystemExit, match=error_message):
+        blurb._update_blurb_template(issue=None, section=section)
+
+
+@pytest.mark.parametrize('section', ['libraryy', 'Not a section'])
+def test_invalid_section_name(section):
+    error_message = re.escape(f'Invalid section name: {section}')
+    error_message = re.compile(rf'{error_message}\n\n.+', re.MULTILINE)
+    with pytest.raises(SystemExit, match=error_message):
+        blurb._extract_section_name(section)
+
+    with pytest.raises(SystemExit, match=error_message):
+        blurb._update_blurb_template(issue=None, section=section)
+
+
+@pytest.mark.parametrize('section', ['', ' ', '      '])
+def test_empty_section_name(section):
+    error_message = re.escape('Empty section name!')
+    with pytest.raises(SystemExit, match=error_message):
+        blurb._extract_section_name('')
+
+    with pytest.raises(SystemExit, match=error_message):
+        blurb._update_blurb_template(issue=None, section='')
+
+
+@pytest.mark.parametrize('invalid', [
+    'gh-issue: ',
+    'gh-issue: 1',
+    'gh-issue',
+])
+def test_illformed_gh_issue_line(invalid, monkeypatch):
+    template = blurb.template.replace('.. gh-issue:', invalid)
+    error_message = re.escape("Can't find gh-issue line to fill!")
+    with monkeypatch.context() as cm:
+        cm.setattr(blurb, 'template', template)
+        with pytest.raises(SystemExit, match=error_message):
+            blurb._update_blurb_template(issue='1234', section=None)
+

--- a/tests/test_blurb_add.py
+++ b/tests/test_blurb_add.py
@@ -128,7 +128,6 @@ class TestValidSectionNames:
         ]
     )
     def test_partial_words(self, section, expect):
-        # test that partial matching from the beginning is supported
         self.check(section, expect)
 
     @pytest.mark.parametrize(
@@ -164,6 +163,7 @@ class TestValidSectionNames:
         ]
     )
     def test_partial_separators(self, section, expect):
+        # normalize the separtors '_', '-', ' ' and '/'
         self.check(section, expect)
 
     @pytest.mark.parametrize(
@@ -182,7 +182,7 @@ class TestValidSectionNames:
         ]
     )
     def test_partial_prefix_words(self, prefix, expect):
-        # spaces are not needed if we cannot find a correct match
+        # try to find a match using prefixes (without separators and lowercase)
         self.check(prefix, expect)
 
     @pytest.mark.parametrize(

--- a/tests/test_blurb_add.py
+++ b/tests/test_blurb_add.py
@@ -81,46 +81,6 @@ def test_invalid_issue_number(issue):
         blurb._update_blurb_template(issue=issue, section=None)
 
 
-@pytest.mark.parametrize(('section_index', 'section_id', 'section_name'), (
-    (0, '1', 'Security'),
-    (1, '2', 'Core and Builtins'),
-    (2, '3', 'Library'),
-    (3, '4', 'Documentation'),
-    (4, '5', 'Tests'),
-    (5, '6', 'Build'),
-    (6, '7', 'Windows'),
-    (7, '8', 'macOS'),
-    (8, '9', 'IDLE'),
-    (9, '10', 'Tools/Demos'),
-    (10, '11', 'C API'),
-))
-def test_valid_section_id(section_index, section_id, section_name):
-    actual = blurb._extract_section_name(section_id)
-    assert actual == section_name
-    assert actual == blurb.sections[section_index]
-
-    res = blurb._update_blurb_template(issue=None, section=section_id)
-    res = res.splitlines()
-
-    for index, _ in enumerate(blurb.sections):
-        if index == section_index:
-            assert f'.. section: {blurb.sections[index]}' in res
-        else:
-            assert f'#.. section: {blurb.sections[index]}' in res
-            assert f'.. section: {blurb.sections[index]}' not in res
-
-
-@pytest.mark.parametrize('section', ['-1', '0', '1337'])
-def test_invalid_section_id(section):
-    error_message = re.escape(f'Invalid section ID: {int(section)}')
-    error_message = re.compile(rf'{error_message}\n\n.+', re.MULTILINE)
-    with pytest.raises(SystemExit, match=error_message):
-        blurb._extract_section_name(section)
-
-    with pytest.raises(SystemExit, match=error_message):
-        blurb._update_blurb_template(issue=None, section=section)
-
-
 class TestValidSectionNames:
     @staticmethod
     def check(section, expect):
@@ -189,7 +149,7 @@ def test_empty_section_name(section):
 
 @pytest.mark.parametrize('section', ['libraryy', 'Not a section'])
 def test_invalid_section_name(section):
-    error_message = re.escape(f'Invalid section name: {section}')
+    error_message = re.escape(f'Invalid section name: {section!r}')
     error_message = re.compile(rf'{error_message}\n\n.+', re.MULTILINE)
     with pytest.raises(SystemExit, match=error_message):
         blurb._extract_section_name(section)
@@ -200,14 +160,16 @@ def test_invalid_section_name(section):
 
 @pytest.mark.parametrize(('section', 'matches'), [
     # 'matches' must be a sorted sequence of matching section names
+    ('c', ['C API', 'Core and Builtins']),
     ('C', ['C API', 'Core and Builtins']),
+    ('t', ['Tests', 'Tools/Demos']),
     ('T', ['Tests', 'Tools/Demos']),
 ])
 def test_ambiguous_section_name(section, matches):
     matching_list = ', '.join(map(repr, matches))
-    error_message = re.escape(f'More than one match for: {section}\n'
+    error_message = re.escape(f'More than one match for: {section!r}\n'
                               f'Matches: {matching_list}')
-    error_message = re.compile(rf'{error_message}\n\n.+', re.MULTILINE)
+    error_message = re.compile(rf'{error_message}', re.MULTILINE)
     with pytest.raises(SystemExit, match=error_message):
         blurb._extract_section_name(section)
 

--- a/tests/test_blurb_add.py
+++ b/tests/test_blurb_add.py
@@ -102,7 +102,6 @@ def test_valid_section_id(section_index, section_id, section_name):
     res = blurb._update_blurb_template(issue=None, section=section_id)
     res = res.splitlines()
 
-
     for index, _ in enumerate(blurb.sections):
         if index == section_index:
             assert f'.. section: {blurb.sections[index]}' in res


### PR DESCRIPTION
Fixes #6. This is an alternative to #15.

@hugovk I've taken out your way of handling positional arguments (but would you consider a PR which refactors blurb in order to use `argparse` instead?). If you prefer `--gh`, I can also rename the variable!