### PR TITLE
Replace hardcoded and outdated `__version__`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        # Temporarily remove 3.13 pending:
+        # https://github.com/pytest-dev/pyfakefs/issues/1017
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,3 @@
-blurb version 1.0
 Part of the blurb package.
 Copyright 2015-2018 by Larry Hastings
 

--- a/src/blurb/__init__.py
+++ b/src/blurb/__init__.py
@@ -1,0 +1,3 @@
+import importlib.metadata
+
+__version__ = importlib.metadata.version(__name__)

--- a/src/blurb/blurb.py
+++ b/src/blurb/blurb.py
@@ -1,9 +1,6 @@
 #!/usr/bin/env python3
 """Command-line tool to manage CPython Misc/NEWS.d entries."""
-__version__ = "1.1.0"
-
 ##
-## blurb version 1.0
 ## Part of the blurb package.
 ## Copyright 2015-2018 by Larry Hastings
 ##
@@ -61,6 +58,8 @@ import tempfile
 import textwrap
 import time
 import unittest
+
+from . import __version__
 
 
 #


### PR DESCRIPTION
In https://github.com/python/blurb/commit/407c9664ee0fa9977bf6a887b635308ab4bc92f9 we switched to using hatchling + hatch-vcs, so the version is based on the tag.

So we no longer need to hardcode it and update it during release.