### PR TITLE
Prepare 1.2.0 release

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,5 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - pre-commit-ci

--- a/README.md
+++ b/README.md
@@ -239,6 +239,18 @@ part of the cherry-picking process.
 
 ## Changelog
 
+### 1.2.0
+
+- Replace spaces with underscores in news directory.
+- Drop support for Python 3.7.
+- Remove `blurb split` command.
+- Replace `gh-issue-NNNN:` with `gh-NNNN:` in the output.
+- Accept GitHub issues numbered only 32426 or above.
+- Improve error checking when parsing a Blurb.
+- Loosen README check for CPython forks.
+- Move code from `python/core-workflow` to own `python/blurb` repo.
+- Deploy to PyPI via Trusted Publishers.
+
 ### 1.1.0
 
 - Support GitHub Issues in addition to b.p.o (bugs.python.org).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,7 +1,7 @@
 # Release Checklist
 
 - [ ] check tests pass on [GitHub Actions](https://github.com/python/blurb/actions)
-      [![GitHub Actions status](https://github.com/python/blurb/actions/workflows/main.yml/badge.svg)](https://github.com/python/blurb/actions/workflows/main.yml)
+      [![GitHub Actions status](https://github.com/python/blurb/actions/workflows/test.yml/badge.svg)](https://github.com/python/blurb/actions/workflows/test.yml)
 
 - [ ] Update [changelog](https://github.com/python/blurb/blob/main/CHANGELOG.md)
 


### PR DESCRIPTION
For https://github.com/python/blurb/issues/4.