### PR TITLE
Fix `blurb` import in the runpy interface

### DIFF
--- a/src/blurb/__main__.py
+++ b/src/blurb/__main__.py
@@ -1,5 +1,5 @@
-"""Run blurb using `python3 blurb/`."""
-import blurb
+"""Run blurb using ``python3 -m blurb``."""
+from blurb import blurb
 
 
 if __name__ == '__main__':

--- a/tox.ini
+++ b/tox.ini
@@ -19,3 +19,5 @@ commands =
       {posargs}
     blurb test
     blurb help
+    {envpython} -I -m blurb test
+    {envpython} -I -m blurb help


### PR DESCRIPTION
When `blurb` was being restructured, the import paths moved to deeper levels of the project layout. It was updated in the console scripts so invoking just the `blurb` command worked but `python -m blurb` didn't. This resulted in breaking the MSI installer smoke testing workflow in CPython's CI [[1]].

Blurb's own CI never invokes said interface, so it had no chance of catching the regression.

This patch corrects the import and adds a smoke test-style invocation of the affected interface.

[1]: https://github.com/python/cpython/issues/121879