### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ and automatically uses the correct file paths.
 You can install **blurb** from PyPI using `pip`.  Alternatively,
 simply add `blurb` to a directory on your path.
 
-**blurb**'s only dependency is Python 3.8+.
-
 
 ## Files used by blurb
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,12 +15,11 @@ maintainers = [
 authors = [
   { name = "Larry Hastings", email = "larry@hastings.org" },
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
   "Intended Audience :: Developers",
   "License :: OSI Approved :: BSD License",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 requires =
     tox>=4.2
 env_list =
-    py{313, 312, 311, 310, 39, 38}
+    py{313, 312, 311, 310, 39}
 
 [testenv]
 extras =


### PR DESCRIPTION
Python 3.8 is end-of-life next month:

* https://devguide.python.org/versions/
* https://peps.python.org/pep-0569/#lifespan
