### PR TITLE
Add `version` subcommand

### DIFF
--- a/src/blurb/blurb.py
+++ b/src/blurb/blurb.py
@@ -744,9 +744,7 @@ def get_subcommand(subcommand):
 
 @subcommand
 def version():
-    """
-Print blurb version.
-    """
+    """Print blurb version."""
     print("blurb version", __version__)
 
 
@@ -825,10 +823,10 @@ If subcommand is not specified, prints one-line summaries for every command.
     print(doc)
     sys.exit(0)
 
-# Make "blurb --help" work.
+# Make "blurb --help/--version/-V" work.
 subcommands["--help"] = help
 subcommands["--version"] = version
-subcommands["-v"] = version
+subcommands["-V"] = version
 
 
 @subcommand

--- a/src/blurb/blurb.py
+++ b/src/blurb/blurb.py
@@ -743,6 +743,15 @@ def get_subcommand(subcommand):
 
 
 @subcommand
+def version():
+    """
+Print blurb version.
+    """
+    print("blurb version", __version__)
+
+
+
+@subcommand
 def help(subcommand=None):
     """
 Print help for subcommands.
@@ -818,6 +827,8 @@ If subcommand is not specified, prints one-line summaries for every command.
 
 # Make "blurb --help" work.
 subcommands["--help"] = help
+subcommands["--version"] = version
+subcommands["-v"] = version
 
 
 @subcommand
@@ -1205,7 +1216,7 @@ def main():
     fn = get_subcommand(subcommand)
 
     # hack
-    if fn in (test, help):
+    if fn in (help, test, version):
         sys.exit(fn(*args))
 
     try:

--- a/tests/test_blurb.py
+++ b/tests/test_blurb.py
@@ -179,3 +179,12 @@ def test_extract_next_filename(news_entry, expected_path, fs):
 
     # Assert
     assert path == expected_path
+
+
+def test_version(capfd):
+    # Act
+    blurb.version()
+
+    # Assert
+    captured = capfd.readouterr()
+    assert captured.out.startswith("blurb version ")

--- a/tox.ini
+++ b/tox.ini
@@ -19,5 +19,7 @@ commands =
       {posargs}
     blurb test
     blurb help
+    blurb --version
     {envpython} -I -m blurb test
     {envpython} -I -m blurb help
+    {envpython} -I -m blurb version


### PR DESCRIPTION
Make it easier to find the version by adding common options.

# Before

```console
❯ blurb --version
Error: Unknown subcommand: --version
Run 'blurb help' for help.

❯ blurb -v
Error: Unknown subcommand: -v
Run 'blurb help' for help.

❯ blurb version
Error: Unknown subcommand: version
Run 'blurb help' for help.

❯ blurb help
blurb version 1.2.2.dev8

Management tool for CPython Misc/NEWS and Misc/NEWS.d entries.

Usage:
    blurb [subcommand] [options...]

Available subcommands:

  add        Add a blurb (a Misc/NEWS.d/next entry) to the current CPython repo.
  export     Removes blurb data files, for building release tarballs/installers.
  help       Print help for subcommands.
  merge      Merge all blurbs together into a single Misc/NEWS file.
  populate   Creates and populates the Misc/NEWS.d directory tree.
  release    Move all new blurbs to a single blurb file for the release.
  test       Run unit tests.  Only works inside source repo, not when installed.

If blurb is run without any arguments, this is equivalent to 'blurb add'.

```

# After

```console
❯ blurb --version
blurb version 1.2.2.dev8

❯ blurb -v
blurb version 1.2.2.dev8

❯ blurb version
blurb version 1.2.2.dev8
```