### PR TITLE
Generate `__version__` at build to avoid slow `importlib.metadata` import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,6 @@ ENV/
 
 # pytest
 .pytest_cache/
+
+# hatch-vcs
+src/*/_version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,9 @@ scripts.blurb = "blurb.blurb:main"
 [tool.hatch]
 version.source = "vcs"
 
+[tool.hatch.build.hooks.vcs]
+version-file = "src/blurb/_version.py"
+
 [tool.hatch.version.raw-options]
 local_scheme = "no-local-version"
 

--- a/src/blurb/__init__.py
+++ b/src/blurb/__init__.py
@@ -1,3 +1,1 @@
-import importlib.metadata
-
-__version__ = importlib.metadata.version(__name__)
+from ._version import __version__


### PR DESCRIPTION
`importlib.metadata` is quite a heavy library to import, and can make CLI use less snappy.

It's only used for fetching the version, and we can pre-generate it as part of our regular build instead.

# Before

```
python -X importtime -c "import blurb" 2> import.log && tuna import.log
```

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/ba17835a-b03d-48d8-932a-4e4f4b76c5bb">

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/691a982c-4cf6-4bd6-a45d-c9a9078080d1">


# After

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/f6e50afc-9de9-4fad-bb00-c693bb83d54a">

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/9e8315c8-a42c-4432-a6b3-4febac537b70">

