### PR TITLE
CI: Lint and test via uv

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,5 +19,4 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-          cache: pip
-      - uses: pre-commit/action@v3.0.1
+      - uses: tox-dev/action-pre-commit-uv@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,6 @@ jobs:
       - name: Publish to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          attestations: true
           repository-url: https://test.pypi.org/legacy/
 
   # Publish to PyPI on GitHub Releases.
@@ -83,5 +82,3 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          attestations: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: hynek/build-and-inspect-python-package@v2
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,17 +26,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
-          cache: pip
 
-      - name: Install dependencies
-        run: |
-          python --version
-          python -m pip install -U pip
-          python -m pip install -U tox
+      - name: Install uv
+        uses: hynek/setup-cached-uv@v2
 
       - name: Tox tests
         run: |
-          tox -e py
+          uvx --with tox-uv tox -e py
 
       - name: Upload coverage
         uses: codecov/codecov-action@v4


### PR DESCRIPTION
* Lint with [action-pre-commit-uv](https://github.com/tox-dev/pre-commit-uv) (60s -> 40s)
* Test with [tox-uv](https://github.com/tox-dev/tox-uv) (120s -> 80s)

# Lint

## Before

No cache: 60s

https://github.com/hugovk/blurb/actions/runs/11635610765/job/32405339441

With cache: 11s

https://github.com/hugovk/blurb/actions/runs/11635702058/job/32405618322

## After

No cache: 37s

https://github.com/hugovk/blurb/actions/runs/11635612034/job/32405343101

With cache: 11s

https://github.com/hugovk/blurb/actions/runs/11635703339/job/32405622146

# Test

## Before

No cache: 2m 0s

https://github.com/hugovk/blurb/actions/runs/11635722298/usage

With cache: 1m 58s

https://github.com/hugovk/blurb/actions/runs/11635745236/usage

## After

No cache: 1m 26s

https://github.com/hugovk/blurb/actions/runs/11635723255/usage

With cache: 1m 22s

https://github.com/hugovk/blurb/actions/runs/11635746618/usage

---

Also:

* Fix security issues found by https://github.com/woodruffw/zizmor
* No need for `with: attestations: true`, it's now the default: https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.11.0