### PR TITLE
Validate gh-issue is int before checking range, and that gh-issue or bpo exists

### DIFF
--- a/src/blurb/blurb.py
+++ b/src/blurb/blurb.py
@@ -486,10 +486,10 @@ class Blurbs(list):
                     try:
                         int(value)
                     except (TypeError, ValueError):
-                        throw(f"Invalid {issue_keys[key]} issue number! ({value!r})")
+                        throw(f"Invalid {issue_keys[key]} number: {value!r}")
 
                 if key == "gh-issue" and int(value) < lowest_possible_gh_issue_number:
-                    throw(f"The gh-issue number must be {lowest_possible_gh_issue_number} or above, not a PR number.")
+                    throw(f"Invalid gh-issue number: {value!r} (must be >= {lowest_possible_gh_issue_number})")
 
                 if key == "section":
                     if no_changes:

--- a/src/blurb/blurb.py
+++ b/src/blurb/blurb.py
@@ -497,6 +497,9 @@ class Blurbs(list):
                     if value not in sections:
                         throw(f"Invalid section {value!r}!  You must use one of the predefined sections.")
 
+            if "gh-issue" not in metadata and "bpo" not in metadata:
+                throw("'gh-issue:' or 'bpo:' must be specified in the metadata!")
+
             if not 'section' in metadata:
                 throw("No 'section' specified.  You must provide one!")
 

--- a/src/blurb/blurb.py
+++ b/src/blurb/blurb.py
@@ -482,14 +482,14 @@ class Blurbs(list):
                 # we'll complain about the *first* error
                 # we see in the blurb file, which is a
                 # better user experience.
-                if key == "gh-issue" and int(value) < lowest_possible_gh_issue_number:
-                    throw(f"The gh-issue number must be {lowest_possible_gh_issue_number} or above, not a PR number.")
-
                 if key in issue_keys:
                     try:
                         int(value)
                     except (TypeError, ValueError):
                         throw(f"Invalid {issue_keys[key]} issue number! ({value!r})")
+
+                if key == "gh-issue" and int(value) < lowest_possible_gh_issue_number:
+                    throw(f"The gh-issue number must be {lowest_possible_gh_issue_number} or above, not a PR number.")
 
                 if key == "section":
                     if no_changes:

--- a/tests/test_blurb.py
+++ b/tests/test_blurb.py
@@ -225,6 +225,10 @@ def test_parse():
             r"Invalid bpo issue number! \('one-two'\)",
         ),
         (
+            "..gh-issue: one-two\n..section: IDLE\nHello world!",
+            r"Invalid GitHub issue number! \('one-two'\)",
+        ),
+        (
             "..gh-issue: 123456\n..section: Funky Kong\nHello world!",
             r"Invalid section 'Funky Kong'!  You must use one of the predefined sections",
         ),

--- a/tests/test_blurb.py
+++ b/tests/test_blurb.py
@@ -1,5 +1,4 @@
 import pytest
-from pyfakefs.fake_filesystem import FakeFilesystem
 
 from blurb import blurb
 

--- a/tests/test_blurb.py
+++ b/tests/test_blurb.py
@@ -217,23 +217,23 @@ def test_parse():
             r"Blurb 'body' can't start with 'gh-'!",
         ),
         (
-            "..gh-issue: 1\n..section: IDLE\nHello world!",
+            ".. gh-issue: 1\n.. section: IDLE\nHello world!",
             r"The gh-issue number must be 32426 or above, not a PR number",
         ),
         (
-            "..bpo: one-two\n..section: IDLE\nHello world!",
+            ".. bpo: one-two\n.. section: IDLE\nHello world!",
             r"Invalid bpo issue number! \('one-two'\)",
         ),
         (
-            "..gh-issue: one-two\n..section: IDLE\nHello world!",
+            ".. gh-issue: one-two\n.. section: IDLE\nHello world!",
             r"Invalid GitHub issue number! \('one-two'\)",
         ),
         (
-            "..gh-issue: 123456\n..section: Funky Kong\nHello world!",
+            ".. gh-issue: 123456\n.. section: Funky Kong\nHello world!",
             r"Invalid section 'Funky Kong'!  You must use one of the predefined sections",
         ),
         (
-            "..gh-issue: 123456\nHello world!",
+            ".. gh-issue: 123456\nHello world!",
             r"No 'section' specified.  You must provide one!",
         ),
         (

--- a/tests/test_blurb.py
+++ b/tests/test_blurb.py
@@ -188,3 +188,60 @@ def test_version(capfd):
     # Assert
     captured = capfd.readouterr()
     assert captured.out.startswith("blurb version ")
+
+
+def test_parse():
+    # Arrange
+    contents = ".. gh-issue: 123456\n.. section: IDLE\nHello world!"
+    blurbs = blurb.Blurbs()
+
+    # Act
+    blurbs.parse(contents)
+
+    # Assert
+    metadata, body = blurbs[0]
+    assert metadata["gh-issue"] == "123456"
+    assert metadata["section"] == "IDLE"
+    assert body == "Hello world!\n"
+
+
+@pytest.mark.parametrize(
+    "contents, expected_error",
+    (
+        (
+            "",
+            r"Blurb 'body' text must not be empty!",
+        ),
+        (
+            "gh-issue: Hello world!",
+            r"Blurb 'body' can't start with 'gh-'!",
+        ),
+        (
+            "..gh-issue: 1\n..section: IDLE\nHello world!",
+            r"The gh-issue number must be 32426 or above, not a PR number",
+        ),
+        (
+            "..bpo: one-two\n..section: IDLE\nHello world!",
+            r"Invalid bpo issue number! \('one-two'\)",
+        ),
+        (
+            "..gh-issue: 123456\n..section: Funky Kong\nHello world!",
+            r"Invalid section 'Funky Kong'!  You must use one of the predefined sections",
+        ),
+        (
+            "..gh-issue: 123456\nHello world!",
+            r"No 'section' specified.  You must provide one!",
+        ),
+        (
+            ".. gh-issue: 123456\n.. section: IDLE\n.. section: IDLE\nHello world!",
+            r"Blurb metadata sets 'section' twice!",
+        ),
+    ),
+)
+def test_parse_no_body(contents, expected_error):
+    # Arrange
+    blurbs = blurb.Blurbs()
+
+    # Act / Assert
+    with pytest.raises(blurb.BlurbError, match=expected_error):
+        blurbs.parse(contents)

--- a/tests/test_blurb.py
+++ b/tests/test_blurb.py
@@ -217,15 +217,15 @@ def test_parse():
         ),
         (
             ".. gh-issue: 1\n.. section: IDLE\nHello world!",
-            r"The gh-issue number must be 32426 or above, not a PR number",
+            r"Invalid gh-issue number: '1' \(must be >= 32426\)",
         ),
         (
             ".. bpo: one-two\n.. section: IDLE\nHello world!",
-            r"Invalid bpo issue number! \('one-two'\)",
+            r"Invalid bpo number: 'one-two'",
         ),
         (
             ".. gh-issue: one-two\n.. section: IDLE\nHello world!",
-            r"Invalid GitHub issue number! \('one-two'\)",
+            r"Invalid GitHub number: 'one-two'",
         ),
         (
             ".. gh-issue: 123456\n.. section: Funky Kong\nHello world!",

--- a/tests/test_blurb.py
+++ b/tests/test_blurb.py
@@ -240,6 +240,10 @@ def test_parse():
             ".. gh-issue: 123456\n.. section: IDLE\n.. section: IDLE\nHello world!",
             r"Blurb metadata sets 'section' twice!",
         ),
+        (
+            ".. section: IDLE\nHello world!",
+            r"'gh-issue:' or 'bpo:' must be specified in the metadata!",
+        ),
     ),
 )
 def test_parse_no_body(contents, expected_error):


### PR DESCRIPTION
Fixes https://github.com/python/blurb/issues/34.

For the first part:

We were checking gh-issue is in the correct range (32426 or higher) before checking it's an int, and so getting a general `ValueError: invalid literal for int() with base 10: ''` instead of a better Blurb one: `Invalid GitHub issue number! ('')`.

For the second part:

Ensure one of `gh-issue` or `bpo` exists in the metadata.

Also add more unit tests for `Blurb.parse()`.