### PR TITLE
Move 'blurb test' subcommand into test suite

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -10,3 +10,4 @@ exclude_also =
 [run]
 omit =
     **/blurb/__main__.py
+    **/blurb/_version.py

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,27 +1,28 @@
 import glob
 import os
-import unittest
+
+import pytest
 
 from blurb.blurb import Blurbs, pushd
 
 
-class TestParserPasses(unittest.TestCase):
+class TestParserPasses:
     directory = "tests/pass"
 
     def filename_test(self, filename):
         b = Blurbs()
         b.load(filename)
-        self.assertTrue(b)
+        assert b
         if os.path.exists(filename + ".res"):
             with open(filename + ".res", encoding="utf-8") as file:
                 expected = file.read()
-            self.assertEqual(str(b), expected)
+            assert str(b) == expected
 
     def test_files(self):
         with pushd(self.directory):
             for filename in glob.glob("*"):
-                if filename[-4:] == ".res":
-                    self.assertTrue(os.path.exists(filename[:-4]), filename)
+                if filename.endswith(".res"):
+                    assert os.path.exists(filename[:-4]), filename
                     continue
                 self.filename_test(filename)
 
@@ -31,5 +32,5 @@ class TestParserFailures(TestParserPasses):
 
     def filename_test(self, filename):
         b = Blurbs()
-        with self.assertRaises(Exception):
+        with pytest.raises(Exception):
             b.load(filename)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,35 @@
+import glob
+import os
+import unittest
+
+from blurb.blurb import Blurbs, pushd
+
+
+class TestParserPasses(unittest.TestCase):
+    directory = "tests/pass"
+
+    def filename_test(self, filename):
+        b = Blurbs()
+        b.load(filename)
+        self.assertTrue(b)
+        if os.path.exists(filename + ".res"):
+            with open(filename + ".res", encoding="utf-8") as file:
+                expected = file.read()
+            self.assertEqual(str(b), expected)
+
+    def test_files(self):
+        with pushd(self.directory):
+            for filename in glob.glob("*"):
+                if filename[-4:] == ".res":
+                    self.assertTrue(os.path.exists(filename[:-4]), filename)
+                    continue
+                self.filename_test(filename)
+
+
+class TestParserFailures(TestParserPasses):
+    directory = "tests/fail"
+
+    def filename_test(self, filename):
+        b = Blurbs()
+        with self.assertRaises(Exception):
+            b.load(filename)

--- a/tox.ini
+++ b/tox.ini
@@ -17,9 +17,7 @@ commands =
       --cov-report term \
       --cov-report xml \
       {posargs}
-    blurb test
     blurb help
     blurb --version
-    {envpython} -I -m blurb test
     {envpython} -I -m blurb help
     {envpython} -I -m blurb version


### PR DESCRIPTION
Right now, there's a `blurb test` command which checks the files in https://github.com/python/blurb/tree/main/tests/fail and https://github.com/python/blurb/tree/main/tests/pass are dealt with as expected.

They're not run as part of the regular unit test suite and aren't part of test coverage.

This PR moves them into the test suite and removes the `blurb test` subcommand.

As an alternative, we could possibly keep the `blurb test` subcommand and also make then runnable via the test suite, but I think it might be cleaner to have them all in one place?