### PR TITLE
Update changelog for 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2.0.0
+
+* Move 'blurb test' subcommand into test suite by @hugovk in https://github.com/python/blurb/pull/37
+* Add support for Python 3.14 by @ezio-melotti in https://github.com/python/blurb/pull/40
+* Validate gh-issue is int before checking range, and that gh-issue or bpo exists by @hugovk in https://github.com/python/blurb/pull/35
+* Replace `safe_mkdir(path)` with `os.makedirs(path, exist_ok=True)` by @hugovk in https://github.com/python/blurb/pull/38
+* Test version handling functions by @hugovk in https://github.com/python/blurb/pull/36
+* CI: Lint and test via uv by @hugovk in https://github.com/python/blurb/pull/32
+
 ## 1.3.0
 
 * Add support for Python 3.13 by @hugovk in https://github.com/python/blurb/pull/26


### PR DESCRIPTION
Major bump, if considering https://github.com/python/blurb/pull/37 as a breaking change because it removes a command, `blurb test`.