### PR TITLE
Add partial and 'smart' matching for ``--section``

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,13 @@ Here's how you interact with the file:
   The section can also be specified via the ``-s`` / ``--section`` option:
 
   ```shell
-  $ blurb add -s Library
-  # or
-  $ blurb add -s library
+  $ blurb add -s 'Library'
+  # or equivalently
+  $ blurb add -s lib
   ```
+
+  The match is performed case insensitively and partial matching is
+  supported as long as the match is unique.
 
 * Finally, go to the end of the file, and enter your `NEWS` entry.
   This should be a single paragraph of English text using


### PR DESCRIPTION
This PR contains the remaining unmerged bits from #16, namely the smart/partial matching. I haven't cleaned it up yet or applied any of Hugo's suggestions from #16.

I think the pattern generation should at the very least be put into a function instead of being global.

A