### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v5

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,4 +1,4 @@
-target-version = "py39"
+target-version = "py310"
 
 [format]
 preview = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,12 +15,11 @@ maintainers = [
 authors = [
   { name = "Larry Hastings", email = "larry@hastings.org" },
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
   "Intended Audience :: Developers",
   "License :: OSI Approved :: BSD License",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 requires =
     tox>=4.2
 env_list =
-    py{314, 313, 312, 311, 310, 39}
+    py{314, 313, 312, 311, 310}
 
 [testenv]
 extras =


### PR DESCRIPTION
It's almost EOL:

* https://devguide.python.org/versions/
* https://peps.python.org/pep-0596/
